### PR TITLE
chore: update git auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,8 +65,13 @@ jobs:
 
       - name: configure git identity
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://$DEPLOY_ACTOR:$DEPLOY_TOKEN@github.com/${{ github.repository }}
+          git config --global user.name $DEPLOY_ACTOR
+          git config --global user.email 'idg.dx@rentpath.com'
+          git config --global http.http.https://github.com/.extraheader "AUTHORIZATION: bearer ${DEPLOY_TOKEN}"
+        env:
+          DEPLOY_ACTOR: rentpath-workflow-bot
+          DEPLOY_TOKEN: ${{ secrets.GPR_PUBLIC_TOKEN }}
 
       - name: publish packages
         run: |


### PR DESCRIPTION
[CARD](https://rentpath.atlassian.net/browse/DX-1103)

We use this configuration for the publish workflow on some of our other `lerna` repos.