### PR TITLE
feat(remoteStore): expose the query function

### DIFF
--- a/packages/react/src/__tests__/remoteStore.test.tsx
+++ b/packages/react/src/__tests__/remoteStore.test.tsx
@@ -153,6 +153,12 @@ describe('remoteStore', () => {
     })
   })
 
+  it('exposes the query function', () => {
+    const fn = async () => {}
+    const rs = createRemoteStore('rs', fn)
+    expect(rs.query).toBe(fn)
+  })
+
   describe('hook', () => {
     describe('fetch', () => {
       it('fetches with no arg', async () => {

--- a/packages/react/src/remoteStore.ts
+++ b/packages/react/src/remoteStore.ts
@@ -27,6 +27,7 @@ export interface FetchedState<Args, Result> {
 }
 
 export interface RemoteStore<Args extends unknown[], Result> {
+  query: (...args: Args) => Promise<Result>
   fetchQuery: (...args: Args) => Promise<Result>
   forceFetchQuery: (...args: Args) => Promise<Result>
   cachedFetchQuery: (...args: Args) => Promise<Result>
@@ -251,6 +252,7 @@ export function createRemoteStore<Args extends unknown[], Result>(
   }
 
   const remoteStore: RemoteStore<Args, Result> = {
+    query,
     fetchQuery: (...args: Args) => fetchQueryBase(args, false),
     forceFetchQuery: (...args: Args) => fetchQueryBase(args, true),
     cachedFetchQuery,


### PR DESCRIPTION
Currently there is no way of calling the query function passed into a remote store directly without it changing the internal store. This isn't suitable for prefetching on the server. This PR exposes the query function directly on the remote store as the prop `query`.